### PR TITLE
let version dependencies be managed debian depends

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -47,3 +47,5 @@ override_dh_auto_install:
 			--install-layout deb; \
 	done
 	rm $(PYBUILD_DESTDIR_python3)usr/bin/versioneer.py
+	# patch requires.txt file by stripping version information - these are provided by debian depends
+	find debian/ -name requires.txt |xargs perl -i -pe "s/(.*)==.*/\1/"


### PR DESCRIPTION
we run into lots of problems if two different package managers want to
resolve version depencies. This should fix https://leap.se/code/issues/7147